### PR TITLE
Add assertions to Delete, Mark, Unmark Commands

### DIFF
--- a/data/duke.txt
+++ b/data/duke.txt
@@ -1,0 +1,2 @@
+T|1| read book
+D|0| return book|1990-11-12

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -40,6 +40,8 @@ public class DeleteCommand extends Command {
         if (tasks.getSize() == 0) {
             throw new DukeException("Task list is already empty.");
         }
+        assert this.num >= 0 : "Index of Task to be deleted has to be at least 1.";
+        assert this.num < tasks.getSize() : "Index of Task to be deleted has to be less than size of Task list.";
         Task task = tasks.getTask(this.num);
         tasks.deleteTask(this.num);
         storage.writeFile(tasks);

--- a/src/main/java/duke/command/MarkCommand.java
+++ b/src/main/java/duke/command/MarkCommand.java
@@ -40,6 +40,8 @@ public class MarkCommand extends Command {
         if (tasks.getSize() == 0) {
             throw new DukeException("Task list is currently empty.");
         }
+        assert this.num >= 0 : "Index of Task to be marked has to be at least 1.";
+        assert this.num < tasks.getSize() : "Index of Task to be marked has to be less than size of Task list.";
         Task task = tasks.getTask(this.num);
         task.markDone();
         storage.writeFile(tasks);

--- a/src/main/java/duke/command/UnMarkCommand.java
+++ b/src/main/java/duke/command/UnMarkCommand.java
@@ -40,6 +40,8 @@ public class UnMarkCommand extends Command {
         if (tasks.getSize() == 0) {
             throw new DukeException("Task list is currently empty.");
         }
+        assert this.num >= 0 : "Index of Task to be unmarked has to be at least 1.";
+        assert this.num < tasks.getSize() : "Index of Task to be unmarked has to be less than size of Task list.";
         Task task = tasks.getTask(this.num);
         task.unMarkDone();
         storage.writeFile(tasks);


### PR DESCRIPTION
Users may input invalid indexes after the commands and be unaware of why
command is not executing.

Assertions can help highlight the issues.

Let's,
* Update the relevant Commands to have assertions that highlight failed
preconditions